### PR TITLE
Skip on Icarus

### DIFF
--- a/tests/designs/sample_module/sample_module.v
+++ b/tests/designs/sample_module/sample_module.v
@@ -34,12 +34,16 @@ module sample_module (
 
     output reg                                  stream_in_ready,
     input                                       stream_in_valid,
+`ifndef __ICARUS__
     input real                                  stream_in_real,
+`endif
     input  [7:0]                                stream_in_data,
     input  [63:0]                               stream_in_data_wide,
 
     input                                       stream_out_ready,
+`ifndef __ICARUS__
     output real                                 stream_out_real,
+`endif
     output reg [7:0]                            stream_out_data_comb,
     output reg [7:0]                            stream_out_data_registered
 );

--- a/tests/test_cases/issue_134/test_reals.py
+++ b/tests/test_cases/issue_134/test_reals.py
@@ -9,7 +9,7 @@ from cocotb.result import TestFailure
 from cocotb.binary import BinaryValue
 
 
-@cocotb.test()
+@cocotb.test(expect_error=cocotb.SIM_NAME in ["Icarus Verilog"])
 def assign_double(dut):
     """
     Assign a random floating point value, read it back from the DUT and check


### PR DESCRIPTION
Needs to be updated to take version into account.

Also uncovers an issue that the failure doesn't tear down correctly so results.xml isn't written.
