### PR TITLE
Issue #17: Add recursive iteration test

### DIFF
--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -292,6 +292,12 @@ class NonConstantObject(SimHandleBase):
         self._sub_handles[index] = SimHandle(new_handle)
         return self._sub_handles[index]
 
+    def __iter__(self):
+        if len(self) == 1:
+            raise StopIteration
+        for i in range(len(self)):
+            yield self[i]
+
     def _getvalue(self):
         result = BinaryValue()
         result.binstr = self._get_value_str()

--- a/cocotb/handle.py
+++ b/cocotb/handle.py
@@ -324,7 +324,7 @@ class NonConstantObject(SimHandleBase):
     def __cmp__(self, other):
 
         # Permits comparison of handles i.e. if clk == dut.clk
-        if isinstance(other, SimHandle):
+        if isinstance(other, SimHandleBase):
             if self._handle == other._handle: return 0
             return 1
 

--- a/tests/test_cases/test_iteration/test_iteration.py
+++ b/tests/test_cases/test_iteration/test_iteration.py
@@ -23,9 +23,29 @@ ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. '''
 
+import logging
+
 import cocotb
 from cocotb.triggers import Timer
 from cocotb.result import TestError, TestFailure
+
+@cocotb.test()
+def recursive_discovery(dut):
+    """
+    Recursively discover every single object in the design
+    """
+    tlog = logging.getLogger("cocotb.test")
+    yield Timer(100)
+    def dump_all_the_things(parent):
+        count = 0
+        for thing in parent:
+            count += 1
+            tlog.info("Found %s.%s (%s)", parent._name, thing._name, type(thing))
+            count += dump_all_the_things(thing)
+        return count
+    total = dump_all_the_things(dut)
+    tlog.info("Found a total of %d things", count)
+
 
 
 @cocotb.test()


### PR DESCRIPTION
This breaks very quickly:

```
# COUT:      0.10ns INFO     cocotb.test                           test_iteration.py:43   in dump_all_the_things             Found dec_viterbi.acs_prob_tdata (<class 'cocotb.handle.ModifiableObject'>)
# COUT:      0.10ns ERROR    cocotb.gpi                                VhpiCbHdl.cpp:336  in get_signal_value_binstr         Size of m_binvalue.value.str was not large enough req=642 have=0
# COUT:      0.10ns ERROR    ..ecursive_discovery.0x7f88389ac1d0           result.py:51   in raise_error                     Send raised exception: object of type 'NoneType' has no len()
```
